### PR TITLE
Add Docker support, Render deployment, and configurable streaming behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
      - `UPSTREAM_TOKEN`: Z.ai 的访问令牌 (必需)
      - `DEFAULT_KEY`: 客户端API密钥 (可选，默认: sk-your-key)
      - `MODEL_NAME`: 显示的模型名称 (可选，默认: GLM-4.5)
+     - `DEFAULT_STREAM`: 默认流式响应 (可选，默认: true)
      - `PORT`: 服务监听端口 (Render会自动设置)
 
 3. 部署完成后，使用Render提供的URL作为OpenAI API的base_url


### PR DESCRIPTION
## 🚀 Features Added

This PR adds comprehensive Docker containerization support, Render deployment configuration, and configurable streaming behavior to make the OpenAI-compatible API proxy easily deployable on cloud platforms with customizable defaults.

## 📋 Changes Made

### 🔧 Core Improvements
- **Environment Variable Support**: Modified `main.go` to support full configuration via environment variables:
  - `UPSTREAM_TOKEN`: Z.ai access token (required)
  - `DEFAULT_KEY`: Client API key (optional, default: sk-your-key)
  - `MODEL_NAME`: Display model name (optional, default: GLM-4.5)
  - `PORT`: Service listening port (optional, default: 8080)
  - `DEBUG_MODE`: Debug mode toggle (optional, default: true)
  - **NEW**: `DEFAULT_STREAM`: Default streaming behavior (optional, default: true)

### 🐳 Docker Support
- **Optimized Dockerfile**: Multi-stage build with Alpine Linux for minimal image size (266B)
- **Security**: Non-root user execution and minimal attack surface
- **Efficiency**: `.dockerignore` file (25B) to optimize build context

### 🌊 Smart Streaming Logic
- **Client Control**: When client specifies `"stream": true/false`, always respects the explicit setting
- **Smart Defaults**: When client doesn't specify `stream` parameter, uses `DEFAULT_STREAM` environment variable
- **Backward Compatible**: Fully compatible with existing OpenAI client libraries
- **Flexible Configuration**: Administrators can set default streaming behavior via environment

### 📚 Documentation
- **Render Deployment Guide**: Step-by-step instructions for cloud deployment
- **Usage Examples**: Python code examples using OpenAI client library
- **Environment Variables**: Complete documentation of all configuration options
- **Project Standards**: Added contribution guidelines, license info, and disclaimer

## 🧪 Testing

- ✅ Verified Go compilation and Docker build
- ✅ Tested API proxy functionality with real Z.ai token
- ✅ Confirmed OpenAI API compatibility (both streaming and non-streaming)
- ✅ Validated DEFAULT_STREAM behavior:
  - `DEFAULT_STREAM=true` + no stream param → streaming response
  - `DEFAULT_STREAM=false` + no stream param → non-streaming response
  - Explicit `"stream": true/false` → always respects client setting

## 🚀 Deployment

### Render Deployment
1. Fork the repository
2. Create a new Web Service on Render
3. Connect your GitHub repository
4. Select Docker as the environment
5. Set the required environment variables
6. Deploy!

### Environment Variables for Render
```bash
UPSTREAM_TOKEN=your_z_ai_token_here     # Required
DEFAULT_KEY=sk-your-key                 # Optional
MODEL_NAME=GLM-4.5                      # Optional
DEFAULT_STREAM=true                     # Optional - controls default streaming
PORT=8080                               # Optional - Render sets automatically
DEBUG_MODE=true                         # Optional
```

## 📦 Files Added/Modified

- `main.go`: Added environment variable configuration and smart streaming logic
- `Dockerfile`: Multi-stage Docker build configuration (266B)
- `.dockerignore`: Docker build optimization (25B)
- `README.md`: Updated with deployment instructions, usage examples, and new environment variables

## 🎯 Use Cases

### Default Streaming Experience
```bash
DEFAULT_STREAM=true  # Users get streaming responses by default
```

### Default Non-Streaming Experience  
```bash
DEFAULT_STREAM=false  # Users get complete responses by default
```

### Client-Controlled Experience
```javascript
// Client always has final control regardless of DEFAULT_STREAM
const response = await openai.chat.completions.create({
  model: "GLM-4.5",
  messages: [...],
  stream: true  // Explicit setting overrides DEFAULT_STREAM
});
```

## 🔗 Related

This enables easy deployment on platforms like Render, Heroku, Railway, and other container-based hosting services while maintaining full OpenAI API compatibility and providing administrators with flexible default behavior configuration.

@copilot1996 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/700ce8d8fcb44c3995795b19f9b46a9f)